### PR TITLE
Remove validation while saving eav.Value

### DIFF
--- a/eav/models.py
+++ b/eav/models.py
@@ -452,13 +452,6 @@ class Value(models.Model):
         verbose_name = _('Attribute')
     )
 
-    def save(self, *args, **kwargs):
-        """
-        Validate and save this value.
-        """
-        self.full_clean()
-        super(Value, self).save(*args, **kwargs)
-
     def _get_value(self):
         """
         Return the python object this value is holding


### PR DESCRIPTION
`full_clean` is being called for `eav.Value`, which calls clean method of each field, calls `clean` method of the model and validates constraints. Django by default does not call this method (except in ModelForm.is_valid()).

As we have not overridden `clean` method to provide any custom validation, we don't really need to call this. Just like django we should rely on database constraints.